### PR TITLE
Define canonical SQL Server diagnostic snapshot schema

### DIFF
--- a/fixtures/sql-server-snapshot.parallelism-sample.json
+++ b/fixtures/sql-server-snapshot.parallelism-sample.json
@@ -1,0 +1,30 @@
+{
+  "environment": {
+    "serverName": "sqlstage-02",
+    "databaseName": "InventoryDb",
+    "sqlServerVersion": "SQL Server 2019 CU28",
+    "capturedAt": "2026-03-09T08:15:00.000Z"
+  },
+  "waitStats": [
+    {
+      "waitType": "CXPACKET",
+      "waitTimeMs": 22110,
+      "signalWaitTimeMs": 4188,
+      "waitingTasksCount": 304
+    },
+    {
+      "waitType": "SOS_SCHEDULER_YIELD",
+      "waitTimeMs": 14002,
+      "signalWaitTimeMs": 3904,
+      "waitingTasksCount": 227
+    }
+  ],
+  "topQueries": [
+    {
+      "queryId": "q-3301",
+      "statementText": "SELECT TOP (100) * FROM dbo.StockLedger ORDER BY ModifiedAt DESC",
+      "averageDurationMs": 94.2,
+      "executionCount": 42881
+    }
+  ]
+}

--- a/fixtures/sql-server-snapshot.sample.json
+++ b/fixtures/sql-server-snapshot.sample.json
@@ -1,0 +1,36 @@
+{
+  "environment": {
+    "serverName": "sqlprod-01",
+    "databaseName": "SalesDb",
+    "sqlServerVersion": "SQL Server 2022 CU14",
+    "capturedAt": "2026-03-10T12:34:56.000Z"
+  },
+  "waitStats": [
+    {
+      "waitType": "PAGEIOLATCH_SH",
+      "waitTimeMs": 182340,
+      "signalWaitTimeMs": 9340,
+      "waitingTasksCount": 1489
+    },
+    {
+      "waitType": "WRITELOG",
+      "waitTimeMs": 58220,
+      "signalWaitTimeMs": 2710,
+      "waitingTasksCount": 612
+    }
+  ],
+  "topQueries": [
+    {
+      "queryId": "q-1001",
+      "statementText": "EXEC dbo.ProcessSalesOrder @OrderId = @P1",
+      "averageDurationMs": 842.7,
+      "executionCount": 1290
+    },
+    {
+      "queryId": "q-2055",
+      "statementText": "SELECT CustomerId, SUM(TotalDue) FROM dbo.Invoice GROUP BY CustomerId",
+      "averageDurationMs": 126.4,
+      "executionCount": 8042
+    }
+  ]
+}

--- a/src/domain/diagnostic-snapshot-loader.test.ts
+++ b/src/domain/diagnostic-snapshot-loader.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { loadDiagnosticSnapshotFixture, parseDiagnosticSnapshot } from "./diagnostic-snapshot";
+import { parseDiagnosticSnapshot } from "./diagnostic-snapshot";
+import { loadDiagnosticSnapshotFixture } from "../ingestion/diagnostic-snapshot-fixture";
 
 test("loadDiagnosticSnapshotFixture parses an offline diagnostic snapshot fixture", () => {
   const snapshot = loadDiagnosticSnapshotFixture(
@@ -39,5 +42,19 @@ test("parseDiagnosticSnapshot rejects malformed input", () => {
         waitStats: [],
       }),
     /diagnostic snapshot\.topQueries must be an array/,
+  );
+});
+
+test("loadDiagnosticSnapshotFixture reports the fixture path for invalid JSON", async () => {
+  const fixturePath = path.join(
+    await fs.promises.mkdtemp(path.join(os.tmpdir(), "snapshot-fixture-")),
+    "invalid-snapshot.json",
+  );
+
+  await fs.promises.writeFile(fixturePath, "{ invalid json", "utf8");
+
+  assert.throws(
+    () => loadDiagnosticSnapshotFixture(fixturePath),
+    /Failed to parse diagnostic snapshot fixture JSON from ".*invalid-snapshot\.json"/,
   );
 });

--- a/src/domain/diagnostic-snapshot-loader.test.ts
+++ b/src/domain/diagnostic-snapshot-loader.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { loadDiagnosticSnapshotFixture, parseDiagnosticSnapshot } from "./diagnostic-snapshot";
+
+test("loadDiagnosticSnapshotFixture parses an offline diagnostic snapshot fixture", () => {
+  const snapshot = loadDiagnosticSnapshotFixture(
+    path.join(__dirname, "../../fixtures/sql-server-snapshot.sample.json"),
+  );
+
+  assert.equal(snapshot.environment.serverName, "sqlprod-01");
+  assert.equal(snapshot.environment.databaseName, "SalesDb");
+  assert.equal(snapshot.environment.sqlServerVersion, "SQL Server 2022 CU14");
+  assert.equal(snapshot.waitStats.length, 2);
+  assert.equal(snapshot.topQueries.length, 2);
+  assert.equal(snapshot.topQueries[0]?.statementText, "EXEC dbo.ProcessSalesOrder @OrderId = @P1");
+});
+
+test("loadDiagnosticSnapshotFixture parses additional sample fixtures", () => {
+  const snapshot = loadDiagnosticSnapshotFixture(
+    path.join(__dirname, "../../fixtures/sql-server-snapshot.parallelism-sample.json"),
+  );
+
+  assert.equal(snapshot.environment.serverName, "sqlstage-02");
+  assert.equal(snapshot.waitStats[0]?.waitType, "CXPACKET");
+  assert.equal(snapshot.topQueries[0]?.executionCount, 42881);
+});
+
+test("parseDiagnosticSnapshot rejects malformed input", () => {
+  assert.throws(
+    () =>
+      parseDiagnosticSnapshot({
+        environment: {
+          serverName: "sql01",
+          databaseName: "SalesDb",
+          sqlServerVersion: "SQL Server 2022",
+          capturedAt: "2026-03-10T12:34:56.000Z",
+        },
+        waitStats: [],
+      }),
+    /diagnostic snapshot\.topQueries must be an array/,
+  );
+});

--- a/src/domain/diagnostic-snapshot.ts
+++ b/src/domain/diagnostic-snapshot.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-
 export interface SqlServerEnvironmentMetadata {
   serverName: string;
   databaseName: string;
@@ -30,7 +28,7 @@ export interface DiagnosticSnapshot {
 export function parseDiagnosticSnapshot(input: unknown): DiagnosticSnapshot {
   const root = expectRecord(input, "diagnostic snapshot");
 
-  return createSnapshot({
+  return {
     environment: parseEnvironment(root.environment),
     waitStats: expectArray(root.waitStats, "diagnostic snapshot.waitStats").map((entry, index) =>
       parseWaitStatSample(entry, index),
@@ -38,12 +36,7 @@ export function parseDiagnosticSnapshot(input: unknown): DiagnosticSnapshot {
     topQueries: expectArray(root.topQueries, "diagnostic snapshot.topQueries").map((entry, index) =>
       parseTopQuerySample(entry, index),
     ),
-  });
-}
-
-export function loadDiagnosticSnapshotFixture(filePath: string): DiagnosticSnapshot {
-  const content = fs.readFileSync(filePath, "utf8");
-  return parseDiagnosticSnapshot(JSON.parse(content) as unknown);
+  };
 }
 
 export function createSnapshot(input: DiagnosticSnapshot): DiagnosticSnapshot {

--- a/src/domain/diagnostic-snapshot.ts
+++ b/src/domain/diagnostic-snapshot.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 export interface SqlServerEnvironmentMetadata {
   serverName: string;
   databaseName: string;
@@ -25,10 +27,112 @@ export interface DiagnosticSnapshot {
   topQueries: TopQuerySample[];
 }
 
+export function parseDiagnosticSnapshot(input: unknown): DiagnosticSnapshot {
+  const root = expectRecord(input, "diagnostic snapshot");
+
+  return createSnapshot({
+    environment: parseEnvironment(root.environment),
+    waitStats: expectArray(root.waitStats, "diagnostic snapshot.waitStats").map((entry, index) =>
+      parseWaitStatSample(entry, index),
+    ),
+    topQueries: expectArray(root.topQueries, "diagnostic snapshot.topQueries").map((entry, index) =>
+      parseTopQuerySample(entry, index),
+    ),
+  });
+}
+
+export function loadDiagnosticSnapshotFixture(filePath: string): DiagnosticSnapshot {
+  const content = fs.readFileSync(filePath, "utf8");
+  return parseDiagnosticSnapshot(JSON.parse(content) as unknown);
+}
+
 export function createSnapshot(input: DiagnosticSnapshot): DiagnosticSnapshot {
   return {
     environment: { ...input.environment },
-    waitStats: [...input.waitStats],
-    topQueries: [...input.topQueries],
+    waitStats: input.waitStats.map((waitStat) => ({ ...waitStat })),
+    topQueries: input.topQueries.map((query) => ({ ...query })),
   };
+}
+
+function parseEnvironment(input: unknown): SqlServerEnvironmentMetadata {
+  const environment = expectRecord(input, "diagnostic snapshot.environment");
+
+  return {
+    serverName: expectString(environment.serverName, "diagnostic snapshot.environment.serverName"),
+    databaseName: expectString(environment.databaseName, "diagnostic snapshot.environment.databaseName"),
+    sqlServerVersion: expectString(
+      environment.sqlServerVersion,
+      "diagnostic snapshot.environment.sqlServerVersion",
+    ),
+    capturedAt: expectString(environment.capturedAt, "diagnostic snapshot.environment.capturedAt"),
+  };
+}
+
+function parseWaitStatSample(input: unknown, index: number): WaitStatSample {
+  const waitStat = expectRecord(input, `diagnostic snapshot.waitStats[${index}]`);
+
+  return {
+    waitType: expectString(waitStat.waitType, `diagnostic snapshot.waitStats[${index}].waitType`),
+    waitTimeMs: expectNumber(waitStat.waitTimeMs, `diagnostic snapshot.waitStats[${index}].waitTimeMs`),
+    signalWaitTimeMs: expectNumber(
+      waitStat.signalWaitTimeMs,
+      `diagnostic snapshot.waitStats[${index}].signalWaitTimeMs`,
+    ),
+    waitingTasksCount: expectNumber(
+      waitStat.waitingTasksCount,
+      `diagnostic snapshot.waitStats[${index}].waitingTasksCount`,
+    ),
+  };
+}
+
+function parseTopQuerySample(input: unknown, index: number): TopQuerySample {
+  const topQuery = expectRecord(input, `diagnostic snapshot.topQueries[${index}]`);
+
+  return {
+    queryId: expectString(topQuery.queryId, `diagnostic snapshot.topQueries[${index}].queryId`),
+    statementText: expectString(
+      topQuery.statementText,
+      `diagnostic snapshot.topQueries[${index}].statementText`,
+    ),
+    averageDurationMs: expectNumber(
+      topQuery.averageDurationMs,
+      `diagnostic snapshot.topQueries[${index}].averageDurationMs`,
+    ),
+    executionCount: expectNumber(
+      topQuery.executionCount,
+      `diagnostic snapshot.topQueries[${index}].executionCount`,
+    ),
+  };
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function expectArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+
+  return value;
+}
+
+function expectString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function expectNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+
+  return value;
 }

--- a/src/ingestion/diagnostic-snapshot-fixture.ts
+++ b/src/ingestion/diagnostic-snapshot-fixture.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import { DiagnosticSnapshot, parseDiagnosticSnapshot } from "../domain/diagnostic-snapshot";
+
+export function loadDiagnosticSnapshotFixture(filePath: string): DiagnosticSnapshot {
+  let content: string;
+
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    throw createWrappedError(
+      `Failed to read diagnostic snapshot fixture from "${filePath}"`,
+      err,
+    );
+  }
+
+  try {
+    return parseDiagnosticSnapshot(JSON.parse(content) as unknown);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      const syntaxError = new SyntaxError(
+        `Failed to parse diagnostic snapshot fixture JSON from "${filePath}": ${err.message}`,
+      );
+      attachCause(syntaxError, err);
+      throw syntaxError;
+    }
+
+    throw err;
+  }
+}
+
+function createWrappedError(message: string, err: unknown): Error {
+  const suffix = err instanceof Error ? err.message : String(err);
+  const wrappedError = new Error(`${message}: ${suffix}`);
+  attachCause(wrappedError, err);
+  return wrappedError;
+}
+
+function attachCause(error: Error, cause: unknown): void {
+  (error as Error & { cause?: unknown }).cause = cause;
+}


### PR DESCRIPTION
## Summary
- define the canonical SQL Server diagnostic snapshot parser and fixture loader
- add offline sample fixtures for wait stats, top queries, and environment metadata
- add focused unit tests for fixture parsing and malformed input rejection

## Testing
- npm test

Refs #2