### PR TITLE
Implement wait stats narrative baseline

### DIFF
--- a/src/domain/wait-stats.test.ts
+++ b/src/domain/wait-stats.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { createSnapshot } from "./diagnostic-snapshot";
 import { inferWaitStatsNarrative } from "./wait-stats";
 
-test("inferWaitStatsNarrative categorizes IO waits", () => {
+test("inferWaitStatsNarrative emits a deterministic IO narrative baseline", () => {
   const snapshot = createSnapshot({
     environment: {
       serverName: "sql01",
@@ -18,6 +18,18 @@ test("inferWaitStatsNarrative categorizes IO waits", () => {
         signalWaitTimeMs: 150,
         waitingTasksCount: 40,
       },
+      {
+        waitType: "WRITELOG",
+        waitTimeMs: 1800,
+        signalWaitTimeMs: 80,
+        waitingTasksCount: 28,
+      },
+      {
+        waitType: "SOS_SCHEDULER_YIELD",
+        waitTimeMs: 1200,
+        signalWaitTimeMs: 500,
+        waitingTasksCount: 18,
+      },
     ],
     topQueries: [],
   });
@@ -25,8 +37,134 @@ test("inferWaitStatsNarrative categorizes IO waits", () => {
   const narrative = inferWaitStatsNarrative(snapshot);
 
   assert.equal(narrative.primaryCategory, "io");
-  assert.match(narrative.summary, /I\/O pressure/);
-  assert.equal(narrative.suggestedNextActions.length, 2);
+  assert.match(narrative.summary, /storage or transaction log throughput pressure/i);
+  assert.equal(narrative.riskLevel, "medium");
+  assert.equal(narrative.confidence, 0.88);
+  assert.deepEqual(narrative.evidence, [
+    "Top wait category IO accounts for 85.0% of observed wait time.",
+    "Dominant waits: PAGEIOLATCH_SH (5000 ms), WRITELOG (1800 ms).",
+    "Signal wait time remains a small share of the dominant waits at 3.4%.",
+  ]);
+  assert.deepEqual(narrative.suggestedNextActions, [
+    {
+      summary: "Inspect file and transaction log latency before changing workload settings.",
+      actionClass: "investigate",
+      riskLevel: "low",
+      confidence: 0.9,
+    },
+    {
+      summary: "Review the queries driving physical reads or log flush volume.",
+      actionClass: "investigate",
+      riskLevel: "low",
+      confidence: 0.85,
+    },
+  ]);
+});
+
+test("inferWaitStatsNarrative emits a deterministic locking narrative baseline", () => {
+  const snapshot = createSnapshot({
+    environment: {
+      serverName: "sql01",
+      databaseName: "finance",
+      sqlServerVersion: "SQL Server 2022",
+      capturedAt: "2026-03-11T00:00:00Z",
+    },
+    waitStats: [
+      {
+        waitType: "LCK_M_X",
+        waitTimeMs: 6200,
+        signalWaitTimeMs: 120,
+        waitingTasksCount: 31,
+      },
+      {
+        waitType: "LCK_M_S",
+        waitTimeMs: 2800,
+        signalWaitTimeMs: 40,
+        waitingTasksCount: 22,
+      },
+      {
+        waitType: "SOS_SCHEDULER_YIELD",
+        waitTimeMs: 700,
+        signalWaitTimeMs: 350,
+        waitingTasksCount: 14,
+      },
+    ],
+    topQueries: [],
+  });
+
+  const narrative = inferWaitStatsNarrative(snapshot);
+
+  assert.equal(narrative.primaryCategory, "locking");
+  assert.match(narrative.summary, /blocking or lock contention/i);
+  assert.equal(narrative.riskLevel, "high");
+  assert.equal(narrative.confidence, 0.92);
+  assert.deepEqual(narrative.suggestedNextActions, [
+    {
+      summary: "Capture the active blocking chain and the lead blocker session.",
+      actionClass: "investigate",
+      riskLevel: "low",
+      confidence: 0.94,
+    },
+    {
+      summary: "Review long-running transactions before considering kill or workload changes.",
+      actionClass: "approval_required",
+      riskLevel: "high",
+      confidence: 0.71,
+    },
+  ]);
+});
+
+test("inferWaitStatsNarrative emits a deterministic CPU narrative baseline", () => {
+  const snapshot = createSnapshot({
+    environment: {
+      serverName: "sql01",
+      databaseName: "finance",
+      sqlServerVersion: "SQL Server 2022",
+      capturedAt: "2026-03-11T00:00:00Z",
+    },
+    waitStats: [
+      {
+        waitType: "SOS_SCHEDULER_YIELD",
+        waitTimeMs: 4200,
+        signalWaitTimeMs: 1700,
+        waitingTasksCount: 38,
+      },
+      {
+        waitType: "CXPACKET",
+        waitTimeMs: 2600,
+        signalWaitTimeMs: 600,
+        waitingTasksCount: 24,
+      },
+      {
+        waitType: "PAGEIOLATCH_SH",
+        waitTimeMs: 900,
+        signalWaitTimeMs: 90,
+        waitingTasksCount: 10,
+      },
+    ],
+    topQueries: [],
+  });
+
+  const narrative = inferWaitStatsNarrative(snapshot);
+
+  assert.equal(narrative.primaryCategory, "cpu");
+  assert.match(narrative.summary, /cpu scheduler pressure or inefficient parallelism/i);
+  assert.equal(narrative.riskLevel, "medium");
+  assert.equal(narrative.confidence, 0.82);
+  assert.deepEqual(narrative.suggestedNextActions, [
+    {
+      summary: "Inspect the top CPU consumers and recent plan regressions.",
+      actionClass: "investigate",
+      riskLevel: "low",
+      confidence: 0.89,
+    },
+    {
+      summary: "Review MAXDOP or cost threshold changes only after confirming the workload pattern.",
+      actionClass: "approval_required",
+      riskLevel: "medium",
+      confidence: 0.67,
+    },
+  ]);
 });
 
 test("inferWaitStatsNarrative handles empty waits", () => {
@@ -45,5 +183,14 @@ test("inferWaitStatsNarrative handles empty waits", () => {
 
   assert.equal(narrative.primaryCategory, "unknown");
   assert.equal(narrative.confidence, 0);
+  assert.equal(narrative.riskLevel, "low");
   assert.match(narrative.summary, /No wait statistics/);
+  assert.deepEqual(narrative.suggestedNextActions, [
+    {
+      summary: "Collect wait stats before attempting diagnosis.",
+      actionClass: "observe",
+      riskLevel: "low",
+      confidence: 1,
+    },
+  ]);
 });

--- a/src/domain/wait-stats.ts
+++ b/src/domain/wait-stats.ts
@@ -7,12 +7,24 @@ export type WaitCategory =
   | "memory"
   | "unknown";
 
+export type WaitActionClass = "observe" | "investigate" | "suggest_change" | "approval_required";
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export interface WaitStatsRecommendation {
+  summary: string;
+  actionClass: WaitActionClass;
+  riskLevel: RiskLevel;
+  confidence: number;
+}
+
 export interface WaitStatsNarrative {
   primaryCategory: WaitCategory;
   summary: string;
   evidence: string[];
   confidence: number;
-  suggestedNextActions: string[];
+  riskLevel: RiskLevel;
+  suggestedNextActions: WaitStatsRecommendation[];
 }
 
 const CPU_WAITS = new Set(["SOS_SCHEDULER_YIELD", "CXCONSUMER", "CXPACKET"]);
@@ -21,31 +33,69 @@ const LOCKING_WAITS = new Set(["LCK_M_S", "LCK_M_X", "LCK_M_U"]);
 const MEMORY_WAITS = new Set(["RESOURCE_SEMAPHORE", "MEMORY_ALLOCATION_EXT"]);
 
 export function inferWaitStatsNarrative(snapshot: DiagnosticSnapshot): WaitStatsNarrative {
-  const topWait = [...snapshot.waitStats].sort((left, right) => right.waitTimeMs - left.waitTimeMs)[0];
-  if (!topWait) {
+  if (snapshot.waitStats.length === 0) {
     return {
       primaryCategory: "unknown",
       summary: "No wait statistics were provided in the diagnostic snapshot.",
       evidence: [],
       confidence: 0,
-      suggestedNextActions: ["Collect wait stats before attempting diagnosis."],
+      riskLevel: "low",
+      suggestedNextActions: [
+        {
+          summary: "Collect wait stats before attempting diagnosis.",
+          actionClass: "observe",
+          riskLevel: "low",
+          confidence: 1,
+        },
+      ],
     };
   }
 
-  const category = classifyWait(topWait.waitType);
-  const evidence = [
-    `Top wait type: ${topWait.waitType}`,
-    `Wait time: ${topWait.waitTimeMs} ms`,
-    `Waiting tasks: ${topWait.waitingTasksCount}`,
-  ];
+  const categoryTotals = summarizeCategoryTotals(snapshot);
+  const category = selectPrimaryCategory(categoryTotals);
+  const dominantSamples = snapshot.waitStats
+    .filter((wait) => classifyWait(wait.waitType) === category)
+    .sort((left, right) => right.waitTimeMs - left.waitTimeMs);
+  const dominantWaitTime = dominantSamples.reduce((total, wait) => total + wait.waitTimeMs, 0);
+  const totalWaitTime = snapshot.waitStats.reduce((total, wait) => total + wait.waitTimeMs, 0);
+  const dominantShare = totalWaitTime === 0 ? 0 : dominantWaitTime / totalWaitTime;
+  const dominantSignalShare =
+    dominantWaitTime === 0
+      ? 0
+      : dominantSamples.reduce((total, wait) => total + wait.signalWaitTimeMs, 0) / dominantWaitTime;
+
+  const evidence = buildEvidence(category, dominantSamples, dominantShare, dominantSignalShare);
 
   return {
     primaryCategory: category,
-    summary: summarizeCategory(category, topWait.waitType),
+    summary: summarizeCategory(category),
     evidence,
-    confidence: category === "unknown" ? 0.35 : 0.75,
+    confidence: confidenceForCategory(category),
+    riskLevel: riskForCategory(category),
     suggestedNextActions: suggestNextActions(category),
   };
+}
+
+function summarizeCategoryTotals(snapshot: DiagnosticSnapshot): Map<WaitCategory, number> {
+  const totals = new Map<WaitCategory, number>([
+    ["cpu", 0],
+    ["io", 0],
+    ["locking", 0],
+    ["memory", 0],
+    ["unknown", 0],
+  ]);
+
+  for (const wait of snapshot.waitStats) {
+    const category = classifyWait(wait.waitType);
+    totals.set(category, (totals.get(category) ?? 0) + wait.waitTimeMs);
+  }
+
+  return totals;
+}
+
+function selectPrimaryCategory(totals: Map<WaitCategory, number>): WaitCategory {
+  const rankedCategories = [...totals.entries()].sort((left, right) => right[1] - left[1]);
+  return rankedCategories[0]?.[0] ?? "unknown";
 }
 
 function classifyWait(waitType: string): WaitCategory {
@@ -64,44 +114,168 @@ function classifyWait(waitType: string): WaitCategory {
   return "unknown";
 }
 
-function summarizeCategory(category: WaitCategory, waitType: string): string {
+function summarizeCategory(category: WaitCategory): string {
   switch (category) {
     case "cpu":
-      return `The snapshot is dominated by ${waitType}, which suggests CPU scheduling or parallelism pressure.`;
+      return "The wait profile points to CPU scheduler pressure or inefficient parallelism as the leading bottleneck.";
     case "io":
-      return `The snapshot is dominated by ${waitType}, which suggests storage or log I/O pressure.`;
+      return "The wait profile points to storage or transaction log throughput pressure as the leading bottleneck.";
     case "locking":
-      return `The snapshot is dominated by ${waitType}, which suggests blocking or lock contention.`;
+      return "The wait profile points to blocking or lock contention as the leading bottleneck.";
     case "memory":
-      return `The snapshot is dominated by ${waitType}, which suggests memory grant or allocation pressure.`;
+      return "The wait profile points to memory grant or allocation pressure as the leading bottleneck.";
     default:
-      return `The snapshot is dominated by ${waitType}, but it does not yet map to a known advisory category.`;
+      return "The wait profile does not yet map cleanly to a supported advisory category.";
   }
 }
 
-function suggestNextActions(category: WaitCategory): string[] {
+function buildEvidence(
+  category: WaitCategory,
+  dominantSamples: DiagnosticSnapshot["waitStats"],
+  dominantShare: number,
+  dominantSignalShare: number,
+): string[] {
+  const evidence = [
+    `Top wait category ${category.toUpperCase()} accounts for ${formatPercent(dominantShare)} of observed wait time.`,
+    `Dominant waits: ${formatDominantWaits(dominantSamples)}.`,
+  ];
+
+  switch (category) {
+    case "io":
+      evidence.push(
+        `Signal wait time remains a small share of the dominant waits at ${formatPercent(dominantSignalShare)}.`,
+      );
+      break;
+    case "cpu":
+      evidence.push(
+        `Signal wait time is elevated within the dominant waits at ${formatPercent(dominantSignalShare)}.`,
+      );
+      break;
+    case "locking":
+      evidence.push(
+        `Lock waits affect ${dominantSamples.reduce((total, wait) => total + wait.waitingTasksCount, 0)} waiting tasks across the dominant samples.`,
+      );
+      break;
+    case "memory":
+      evidence.push(
+        `Memory-related waits account for ${formatPercent(dominantShare)} of total wait time in this snapshot.`,
+      );
+      break;
+    default:
+      evidence.push("Additional workload context is required to refine the diagnosis.");
+      break;
+  }
+
+  return evidence;
+}
+
+function formatDominantWaits(waits: DiagnosticSnapshot["waitStats"]): string {
+  const leadingWaits = waits.slice(0, 2).map((wait) => `${wait.waitType} (${wait.waitTimeMs} ms)`);
+  return leadingWaits.join(", ");
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function confidenceForCategory(category: WaitCategory): number {
+  switch (category) {
+    case "cpu":
+      return 0.82;
+    case "io":
+      return 0.88;
+    case "locking":
+      return 0.92;
+    case "memory":
+      return 0.86;
+    default:
+      return 0.35;
+  }
+}
+
+function riskForCategory(category: WaitCategory): RiskLevel {
+  switch (category) {
+    case "locking":
+      return "high";
+    case "cpu":
+    case "io":
+    case "memory":
+      return "medium";
+    default:
+      return "low";
+  }
+}
+
+function suggestNextActions(category: WaitCategory): WaitStatsRecommendation[] {
   switch (category) {
     case "cpu":
       return [
-        "Inspect top CPU-consuming queries and recent plan regressions.",
-        "Review parallelism settings and recent workload changes.",
+        {
+          summary: "Inspect the top CPU consumers and recent plan regressions.",
+          actionClass: "investigate",
+          riskLevel: "low",
+          confidence: 0.89,
+        },
+        {
+          summary: "Review MAXDOP or cost threshold changes only after confirming the workload pattern.",
+          actionClass: "approval_required",
+          riskLevel: "medium",
+          confidence: 0.67,
+        },
       ];
     case "io":
       return [
-        "Inspect storage latency and transaction log throughput.",
-        "Review top queries with high physical reads or log pressure.",
+        {
+          summary: "Inspect file and transaction log latency before changing workload settings.",
+          actionClass: "investigate",
+          riskLevel: "low",
+          confidence: 0.9,
+        },
+        {
+          summary: "Review the queries driving physical reads or log flush volume.",
+          actionClass: "investigate",
+          riskLevel: "low",
+          confidence: 0.85,
+        },
       ];
     case "locking":
       return [
-        "Inspect blocking chains and recent long-running transactions.",
-        "Capture the most contended objects and lock modes.",
+        {
+          summary: "Capture the active blocking chain and the lead blocker session.",
+          actionClass: "investigate",
+          riskLevel: "low",
+          confidence: 0.94,
+        },
+        {
+          summary: "Review long-running transactions before considering kill or workload changes.",
+          actionClass: "approval_required",
+          riskLevel: "high",
+          confidence: 0.71,
+        },
       ];
     case "memory":
       return [
-        "Inspect memory grants and recent query concurrency spikes.",
-        "Check for plan regressions that increased grant size.",
+        {
+          summary: "Inspect memory grants and recent query concurrency spikes.",
+          actionClass: "investigate",
+          riskLevel: "low",
+          confidence: 0.9,
+        },
+        {
+          summary: "Check for plan regressions that increased grant size before changing server memory settings.",
+          actionClass: "approval_required",
+          riskLevel: "medium",
+          confidence: 0.7,
+        },
       ];
     default:
-      return ["Collect additional workload context before making a recommendation."];
+      return [
+        {
+          summary: "Collect additional workload context before making a recommendation.",
+          actionClass: "observe",
+          riskLevel: "low",
+          confidence: 0.8,
+        },
+      ];
   }
 }


### PR DESCRIPTION
## Summary
- add deterministic wait stats narrative interpretation for representative baseline categories
- emit structured evidence, confidence, risk level, and policy-classified next actions
- cover IO, locking, CPU, and empty-wait cases with focused tests

## Testing
- npm test

Closes #3